### PR TITLE
Add Encryption Support

### DIFF
--- a/.idea/.idea.FS/.idea/deploymentTargetSelector.xml
+++ b/.idea/.idea.FS/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="FS">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2024-09-07T06:01:09.870638900Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Paull\.android\avd\Medium_Phone_API_35.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/.idea.FS/.idea/libraries/androidx_window_window_java.xml
+++ b/.idea/.idea.FS/.idea/libraries/androidx_window_window_java.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+  <library name="androidx.window.window-java">
+    <CLASSES>
+      <root url="file://$USER_HOME$/AppData/Local/Temp/JetBrains/xamarinAarPackages/androidx.window.window-java/classes.jar" />
+      <root url="file://$USER_HOME$/AppData/Local/Temp/JetBrains/xamarinAarPackages/androidx.window.window-java/res" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/.idea.FS/.idea/libraries/org_jetbrains_kotlinx_kotlinx_coroutines_core_1_7_2.xml
+++ b/.idea/.idea.FS/.idea/libraries/org_jetbrains_kotlinx_kotlinx_coroutines_core_1_7_2.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="org.jetbrains.kotlinx.kotlinx-coroutines-core-1.7.2">
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.nuget/packages/xamarin.kotlinx.coroutines.core/1.7.2.1/jar/org.jetbrains.kotlinx.kotlinx-coroutines-core-1.7.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/FS/FS.csproj
+++ b/FS/FS.csproj
@@ -61,6 +61,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
         <PackageReference Include="CommunityToolkit.Maui" Version="9.0.0" />
         <PackageReference Include="CommunityToolkit.Maui.Markup" Version="4.0.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/FS/Models/CreateTransferFile.cs
+++ b/FS/Models/CreateTransferFile.cs
@@ -11,6 +11,9 @@ public class CreateTransferFile : IEquatable<CreateTransferFile>
     public string FileName { get; set; }
     public long FileSize { get; set; }
     public string FileId { get; set; }
+            
+    public byte[]? FileIV { get; set; }
+    public string? FileAead { get; set; }
 
     public CreateTransferFile(string mimeType, Task<Stream> fileStream, string fullPath, string fName, long fileSize, string fileId)
     {
@@ -20,6 +23,8 @@ public class CreateTransferFile : IEquatable<CreateTransferFile>
         FileName = fName;
         FileSize = fileSize;
         FileId = fileId;
+        FileIV = null;
+        FileAead = null;
     }
 
 

--- a/FS/Models/FileSenderServer.cs
+++ b/FS/Models/FileSenderServer.cs
@@ -253,7 +253,7 @@ public class FileSenderServer
             throw;
         }
     }
-    public async Task SendTransfer(IDictionary<string,CreateTransferFile>files, Transfer transferResponse, CancellationToken cancellationToken)
+    public async Task SendTransfer(IDictionary<string,CreateTransferFile>files, Transfer transferResponse,byte[] key, CancellationToken cancellationToken)
     {
         cancellationToken.Register(() =>
         {
@@ -268,12 +268,7 @@ public class FileSenderServer
             _initialCount = transferResponse.Files.Aggregate(0,
                 (i, f) => i + (int)Math.Ceiling(f.Size / (decimal)config.ChunkSize));
             _currentCount = _initialCount;
-            var key = new Rfc2898DeriveBytes(
-                    Encoding.ASCII.GetBytes("!1TheTestPassword"), 
-                    Encoding.ASCII.GetBytes(transferResponse.Salt), 
-                    config.EncryptionOptions!.PasswordHashIterations, //todo: change change change!!!!
-                    HashAlgorithmName.SHA256) //todo: change change change!!!!
-                .GetBytes(256 / 8); //todo: change change change!!!
+            
             foreach (var f in transferResponse.Files)
             {
                 for (long i = 0; i < f.Size; i += config.ChunkSize)

--- a/FS/Models/FileSenderServer.cs
+++ b/FS/Models/FileSenderServer.cs
@@ -156,8 +156,8 @@ public class FileSenderServer
         }
     }
 
-    public async Task<Transfer> CreateTransfer(string[] recepients, string subject, string message,
-        CreateTransferFile[] files)
+    public async Task<Transfer> CreateTransfer(string[] recipients, string subject, string message,
+        string password, IList<TransferOptions> transferOptions,CreateTransferFile[] files)
     {
         
         Debug.WriteLine($"starting test transfer");
@@ -184,7 +184,7 @@ public class FileSenderServer
         }
 
         transferContent["files"] = filesObject.ToArray();//;
-        transferContent["recipients"] = recepients;
+        transferContent["recipients"] = recipients;
         transferContent["subject"] = subject;
         transferContent["message"] = message;
         transferContent["expires"] = DateTimeOffset.UtcNow.AddDays(config.DefaultTransferDaysValid).ToUnixTimeSeconds();
@@ -194,6 +194,11 @@ public class FileSenderServer
         {
             ["get_a_link"] = 0
         };
+        foreach (var option in transferOptions)
+        {
+            optionsDict[option.ToString()] = 1;
+        }
+        
         transferContent["options"] = optionsDict;
 
         var createTransferCall = await Call(HttpVerb.Post, "/transfer", new Dictionary<string, string>(), transferContent, null,

--- a/FS/Models/FileSenderServer.cs
+++ b/FS/Models/FileSenderServer.cs
@@ -405,6 +405,11 @@ public class FileSenderServer
 
             //
             var handler = new HttpClientHandler();
+#if DEBUG
+            handler.ServerCertificateCustomValidationCallback =
+                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+#endif
+
             var client = new HttpClient(handler);
             client.BaseAddress = new Uri(baseUrl);
             var queryString = HttpUtility.ParseQueryString(string.Empty);

--- a/FS/Models/FileSenderServer.cs
+++ b/FS/Models/FileSenderServer.cs
@@ -270,7 +270,7 @@ public class FileSenderServer
             _currentCount = _initialCount;
             var key = new Rfc2898DeriveBytes(
                     Encoding.ASCII.GetBytes("!1TheTestPassword"), 
-                    Convert.FromBase64String(transferResponse.Salt), 
+                    Encoding.ASCII.GetBytes(transferResponse.Salt), 
                     config.EncryptionOptions!.PasswordHashIterations, //todo: change change change!!!!
                     HashAlgorithmName.SHA256) //todo: change change change!!!!
                 .GetBytes(256 / 8); //todo: change change change!!!

--- a/FS/Models/FileSenderServerConfig.cs
+++ b/FS/Models/FileSenderServerConfig.cs
@@ -13,6 +13,7 @@ public class FileSenderServerConfig(
     int workerRetries,
     int maxFilesCount,
     long maxTransferSize,
+    ServerEncryptionOptions? encryptionOptions,
     List<string> bannedFileTypes)
 {
     public string BaseUrl = baseUrl;
@@ -26,4 +27,5 @@ public class FileSenderServerConfig(
     public int MaxFilesCount = maxFilesCount;
     public long MaxTransferSize = maxTransferSize;
     public IList<string> BannedFileTypes = bannedFileTypes;
+    public ServerEncryptionOptions? EncryptionOptions = encryptionOptions;
 }

--- a/FS/Models/FileSenderServerConfig.cs
+++ b/FS/Models/FileSenderServerConfig.cs
@@ -9,6 +9,7 @@ public class FileSenderServerConfig(
     int chunkSize,
     string siteName,
     int defaultTransferDaysValid,
+    int maxTransferDaysValid,
     int workerCount,
     int workerRetries,
     int maxFilesCount,
@@ -22,6 +23,7 @@ public class FileSenderServerConfig(
     public int ChunkSize = chunkSize;
     public string SiteName = siteName;
     public int DefaultTransferDaysValid = defaultTransferDaysValid;
+    public int MaxTransferDaysValid = maxTransferDaysValid;
     public int WorkerCount = workerCount;
     public int WorkerRetries = workerRetries;
     public int MaxFilesCount = maxFilesCount;

--- a/FS/Models/FileSenderServerConfigFactory.cs
+++ b/FS/Models/FileSenderServerConfigFactory.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace FS.Models;
 
@@ -55,7 +57,7 @@ public static class FileSenderServerConfigFactory
         int chunkSize = match.Success
             ? int.Parse(match.Groups[1].Value)
             : throw new InvalidDataException("No chunk size provided");
-
+        
         var bannedFileTypes = new List<string>();
         regex = new Regex(@"ban_extension:\s*'(\S+)',");
         match = regex.Match(configText);
@@ -67,8 +69,71 @@ public static class FileSenderServerConfigFactory
                 bannedFileTypes.Add(extension);
             }
         }
+        ServerEncryptionOptions? encryptionDetails = new ServerEncryptionOptions();
+        try
+        {
+            regex = new Regex(@"encryption_password_must_have_upper_and_lower_case: (\w+)");
+            match = regex.Match(configText);
+            bool passwordMixedCaseRequired = match.Success && match.Groups[1].Value == "true";
+            encryptionDetails.PasswordMixedCaseRequired = passwordMixedCaseRequired;
+
+            // Example regex pattern for password_numbers_required
+            regex = new Regex(@"encryption_password_must_have_numbers: (\w+)");
+            match = regex.Match(configText);
+            bool passwordNumbersRequired = match.Success && match.Groups[1].Value == "true";
+            encryptionDetails.PasswordNumbersRequired = passwordNumbersRequired;
+
+            // Example regex pattern for password_special_required
+            regex = new Regex(@"encryption_password_must_have_special_characters: (\w+)");
+            match = regex.Match(configText);
+            bool passwordSpecialRequired = match.Success && match.Groups[1].Value == "true";
+            encryptionDetails.PasswordSpecialRequired = passwordSpecialRequired;
+
+            // Example regex pattern for iv_len
+            regex = new Regex(@"crypto_iv_len\D+(\d+)");
+            match = regex.Match(configText);
+            int ivLen = match.Success ? int.Parse(match.Groups[1].Value) : 0;
+            encryptionDetails.IvLength = ivLen;
+
+            // Example regex pattern for password_hash_iterations
+            regex = new Regex(@"encryption_password_hash_iterations_new_files\D+(\d+)");
+            match = regex.Match(configText);
+            int passwordHashIterations = match.Success ? int.Parse(match.Groups[1].Value) : 0;
+            encryptionDetails.PasswordHashIterations = passwordHashIterations;
+
+            // Example regex pattern for crypt_type
+            regex = new Regex(@"crypto_crypt_name: '(.+)'");
+            match = regex.Match(configText);
+            SupportedCryptTypes cryptType = match.Success
+                ? (SupportedCryptTypes)Enum.Parse(typeof(SupportedCryptTypes), match.Groups[1].Value.Replace("-", ""))
+                : default;
+            encryptionDetails.CryptType = cryptType;
+
+            // Example regex pattern for hash_name
+            regex = new Regex(@"crypto_hash_name: '(.+)'");
+            match = regex.Match(configText);
+            SupportedHashTypes hashName = match.Success
+                ? (SupportedHashTypes)Enum.Parse(typeof(SupportedHashTypes), match.Groups[1].Value.Replace("-", ""))
+                : default;
+            encryptionDetails.HashName = hashName;
+
+            // Example regex pattern for upload_chunk_base64_mode
+            regex = new Regex(@"encryption_encode_encrypted_chunks_in_base64_during_upload: (\w+)");
+            match = regex.Match(configText);
+            bool uploadChunkBase64Mode = match.Success && match.Groups[1].Value == "true";
+            encryptionDetails.UploadChunkBase64Mode = uploadChunkBase64Mode;
+            if(uploadChunkBase64Mode)
+            {   //todo.
+                throw (new NotImplementedException("UploadChunkBase64Mode is not implemented"));
+            }
+        }
+        catch (Exception e)
+        {
+            encryptionDetails = null;
+            Debug.WriteLine($"Failed to capture encryption details: \n{e}");
+        }
 
         return new FileSenderServerConfig(baseUrl, username, apikey, chunkSize, siteName, defaultTransferDaysValid,
-            workerCount, workerRetries, maxFilesCount, maxTransferSize,bannedFileTypes);
+            workerCount, workerRetries, maxFilesCount, maxTransferSize,encryptionDetails,bannedFileTypes);
     }
 }

--- a/FS/Models/FileSenderServerConfigFactory.cs
+++ b/FS/Models/FileSenderServerConfigFactory.cs
@@ -78,47 +78,44 @@ public static class FileSenderServerConfigFactory
         {
             regex = new Regex(@"encryption_password_must_have_upper_and_lower_case: (\w+)");
             match = regex.Match(configText);
-            bool passwordMixedCaseRequired = match.Success && match.Groups[1].Value == "true";
-            encryptionDetails.PasswordMixedCaseRequired = passwordMixedCaseRequired;
+            encryptionDetails.PasswordMixedCaseRequired =  match.Groups[1].Value == "true";
 
             // Example regex pattern for password_numbers_required
             regex = new Regex(@"encryption_password_must_have_numbers: (\w+)");
             match = regex.Match(configText);
-            bool passwordNumbersRequired = match.Success && match.Groups[1].Value == "true";
-            encryptionDetails.PasswordNumbersRequired = passwordNumbersRequired;
+            encryptionDetails.PasswordNumbersRequired =  match.Groups[1].Value == "true";
 
             // Example regex pattern for password_special_required
             regex = new Regex(@"encryption_password_must_have_special_characters: (\w+)");
             match = regex.Match(configText);
-            bool passwordSpecialRequired = match.Success && match.Groups[1].Value == "true";
-            encryptionDetails.PasswordSpecialRequired = passwordSpecialRequired;
+            encryptionDetails.PasswordSpecialRequired = match.Groups[1].Value == "true";
 
             // Example regex pattern for iv_len
             regex = new Regex(@"crypto_iv_len\D+(\d+)");
             match = regex.Match(configText);
-            int ivLen = match.Success ? int.Parse(match.Groups[1].Value) : 0;
-            encryptionDetails.IvLength = ivLen;
-
+            encryptionDetails.IvLength =  int.Parse(match.Groups[1].Value);
+            
+            regex = new Regex(@"encryption_min_password_length\D+(\d+)");
+            match = regex.Match(configText);
+            encryptionDetails.PasswordMinLength = int.Parse(match.Groups[1].Value);
+            
             // Example regex pattern for password_hash_iterations
             regex = new Regex(@"encryption_password_hash_iterations_new_files\D+(\d+)");
             match = regex.Match(configText);
-            int passwordHashIterations = match.Success ? int.Parse(match.Groups[1].Value) : 0;
-            encryptionDetails.PasswordHashIterations = passwordHashIterations;
+            encryptionDetails.PasswordHashIterations =  int.Parse(match.Groups[1].Value);
 
             // Example regex pattern for crypt_type
             regex = new Regex(@"crypto_crypt_name: '(.+)'");
             match = regex.Match(configText);
-            SupportedCryptTypes cryptType = match.Success
-                ? (SupportedCryptTypes)Enum.Parse(typeof(SupportedCryptTypes), match.Groups[1].Value.Replace("-", ""))
-                : default;
+            SupportedCryptTypes cryptType =
+                (SupportedCryptTypes)Enum.Parse(typeof(SupportedCryptTypes), match.Groups[1].Value.Replace("-", ""));
             encryptionDetails.CryptType = cryptType;
 
             // Example regex pattern for hash_name
             regex = new Regex(@"crypto_hash_name: '(.+)'");
             match = regex.Match(configText);
-            SupportedHashTypes hashName = match.Success
-                ? (SupportedHashTypes)Enum.Parse(typeof(SupportedHashTypes), match.Groups[1].Value.Replace("-", ""))
-                : default;
+            SupportedHashTypes hashName = 
+                (SupportedHashTypes)Enum.Parse(typeof(SupportedHashTypes), match.Groups[1].Value.Replace("-", ""));
             encryptionDetails.HashName = hashName;
 
             // Example regex pattern for upload_chunk_base64_mode

--- a/FS/Models/FileSenderServerConfigFactory.cs
+++ b/FS/Models/FileSenderServerConfigFactory.cs
@@ -44,6 +44,10 @@ public static class FileSenderServerConfigFactory
         match = regex.Match(configText);
         int maxFilesCount = match.Success ? int.Parse(match.Groups[1].Value) : 1000;
 
+        regex = new Regex(@"max_transfer_days_valid\D*(\d+)");
+        match = regex.Match(configText);
+        int maxDaysValid = match.Success ? int.Parse(match.Groups[1].Value) : defaultTransferDaysValid;
+        
         regex = new Regex(@"max_transfer_size\D*(\d+)");
         match = regex.Match(configText);
         long maxTransferSize = match.Success ? long.Parse(match.Groups[1].Value) : 107374182400;
@@ -133,7 +137,7 @@ public static class FileSenderServerConfigFactory
             Debug.WriteLine($"Failed to capture encryption details: \n{e}");
         }
 
-        return new FileSenderServerConfig(baseUrl, username, apikey, chunkSize, siteName, defaultTransferDaysValid,
+        return new FileSenderServerConfig(baseUrl, username, apikey, chunkSize, siteName, defaultTransferDaysValid,maxDaysValid,
             workerCount, workerRetries, maxFilesCount, maxTransferSize,encryptionDetails,bannedFileTypes);
     }
 }

--- a/FS/Models/ServerEncryptionOptions.cs
+++ b/FS/Models/ServerEncryptionOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace FS.Models;
+
+public class ServerEncryptionOptions
+{
+    public bool PasswordMixedCaseRequired { get; set; }
+    public bool PasswordNumbersRequired { get; set; }
+    public bool PasswordSpecialRequired { get; set; }
+    public int IvLength { get; set; }
+    public int PasswordHashIterations { get; set; }
+    public SupportedCryptTypes CryptType { get; set; }
+    public SupportedHashTypes HashName { get; set; }
+    public bool UploadChunkBase64Mode { get; set; }
+}

--- a/FS/Models/ServerEncryptionOptions.cs
+++ b/FS/Models/ServerEncryptionOptions.cs
@@ -5,6 +5,7 @@ public class ServerEncryptionOptions
     public bool PasswordMixedCaseRequired { get; set; }
     public bool PasswordNumbersRequired { get; set; }
     public bool PasswordSpecialRequired { get; set; }
+    public int PasswordMinLength { get; set; }
     public int IvLength { get; set; }
     public int PasswordHashIterations { get; set; }
     public SupportedCryptTypes CryptType { get; set; }

--- a/FS/Models/SupportedCryptTypes.cs
+++ b/FS/Models/SupportedCryptTypes.cs
@@ -1,0 +1,6 @@
+﻿namespace FS.Models;
+
+public enum SupportedCryptTypes
+{
+    AESGCM
+}

--- a/FS/Models/SupportedHashTypes.cs
+++ b/FS/Models/SupportedHashTypes.cs
@@ -1,0 +1,6 @@
+﻿namespace FS.Models;
+
+public enum SupportedHashTypes
+{
+    SHA256
+}

--- a/FS/Models/TransferOptions.cs
+++ b/FS/Models/TransferOptions.cs
@@ -1,0 +1,20 @@
+﻿namespace FS.Models;
+
+public enum TransferOptions
+{
+    email_me_copies,
+    email_me_on_expire,
+    email_upload_complete,
+    email_download_complete,
+    email_daily_statistics,
+    email_report_on_closing,
+    enable_recipient_email_download_complete,
+    add_me_to_recipients,
+    email_recipient_when_transfer_expires,
+    get_a_link,
+    hide_sender_email,
+    redirect_url_on_complete,
+    encryption,
+    collection,
+    must_be_logged_in_to_download,
+}

--- a/FS/Utilities/BoolToDoubleConverter.cs
+++ b/FS/Utilities/BoolToDoubleConverter.cs
@@ -1,0 +1,24 @@
+﻿using System.Globalization;
+
+namespace FS.Utilities;
+
+public class BoolToFloatConverter : IValueConverter
+{
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is bool boolValue)
+            {
+                return boolValue ? 1.0 : 0.0;
+            }
+            return 0.0;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is float doubleValue)
+            {
+                return doubleValue == 1.0;
+            }
+            return false;
+        }
+}

--- a/FS/ViewModels/CreateTransferViewModel.cs
+++ b/FS/ViewModels/CreateTransferViewModel.cs
@@ -100,13 +100,25 @@ public partial class CreateTransferViewModel : ObservableObject
     [RelayCommand]
     public void ValidateTransfer()
     {
-        IsValidTransferState = SelectedFiles.Count > 0 && ValidateRecipientFiled();
+        IsValidTransferState = SelectedFiles.Count > 0 && ValidateRecipientFiled() && ValidatePassword();
         return;
     }
 
-    [RelayCommand]
-    public void ValidatePassword()
+    public bool ValidatePassword()
     {
+        if(Password.Length == 0 || FsServer.config.EncryptionOptions is null)
+        {
+            return true;
+        }
+        
+        if ((FsServer.config.EncryptionOptions.PasswordNumbersRequired && Password.Any(char.IsNumber)) ||
+            (FsServer.config.EncryptionOptions.PasswordSpecialRequired && Password.Any(char.IsSymbol)) ||
+            (FsServer.config.EncryptionOptions.PasswordMixedCaseRequired && Password.Any(char.IsUpper) && Password.Any(char.IsLower)) || 
+            (Password.Length < FsServer.config.EncryptionOptions.PasswordMinLength))
+        {
+            return false;
+        }
+        return true;
     }
 
     private EmailAddressAttribute emailTool =  new EmailAddressAttribute();

--- a/FS/ViewModels/CreateTransferViewModel.cs
+++ b/FS/ViewModels/CreateTransferViewModel.cs
@@ -111,14 +111,12 @@ public partial class CreateTransferViewModel : ObservableObject
             return true;
         }
         
-        if ((FsServer.config.EncryptionOptions.PasswordNumbersRequired && Password.Any(char.IsNumber)) ||
-            (FsServer.config.EncryptionOptions.PasswordSpecialRequired && Password.Any(char.IsSymbol)) ||
-            (FsServer.config.EncryptionOptions.PasswordMixedCaseRequired && Password.Any(char.IsUpper) && Password.Any(char.IsLower)) || 
-            (Password.Length < FsServer.config.EncryptionOptions.PasswordMinLength))
-        {
-            return false;
-        }
-        return true;
+        return !((FsServer.config.EncryptionOptions.PasswordNumbersRequired && !Password.Any(char.IsNumber)) ||
+                 (FsServer.config.EncryptionOptions.PasswordSpecialRequired &&
+                    !Password.Any(c => !char.IsNumber(c) && !char.IsLetter(c))) ||
+                 (FsServer.config.EncryptionOptions.PasswordMixedCaseRequired 
+                    && !(Password.Any(char.IsUpper) && Password.Any(char.IsLower))) ||
+                 (Password.Length < FsServer.config.EncryptionOptions.PasswordMinLength));
     }
 
     private EmailAddressAttribute emailTool =  new EmailAddressAttribute();

--- a/FS/ViewModels/CreateTransferViewModel.cs
+++ b/FS/ViewModels/CreateTransferViewModel.cs
@@ -31,20 +31,40 @@ public partial class CreateTransferViewModel : ObservableObject
     [ObservableProperty]
     private IDictionary<string, Guid> fileListIndex = new Dictionary<string, Guid>();
 
+    [ObservableProperty] 
+    private string password;
+    
     [ObservableProperty]
     private bool isValidTransferState;
+
+    [ObservableProperty] 
+    private DateTime transferExpiryDate;
+    
+    [ObservableProperty] 
+    public DateTime transferMinExpiryDate;
+    
+    [ObservableProperty] 
+    public DateTime transferMaxExpiryDate;
+    
+    [ObservableProperty] 
+    public bool encryptionEnabled;
     
     private Transfer? activeTransfer;
     public CancellationTokenSource TransferCancellationToken = new CancellationTokenSource();
     public CreateTransferViewModel(FileSenderServer fsServer)
     {
         FsServer = fsServer;
+        EncryptionEnabled = fsServer.config.EncryptionOptions is null;
+        Password = "";
         Recipient = "";
         Subject = "";
         Description = "";
         TransferActive = false;
         SelectedFiles = [];
         IsValidTransferState = false;
+        TransferMaxExpiryDate = DateTime.Today + TimeSpan.FromDays(fsServer.config.MaxTransferDaysValid);
+        TransferMinExpiryDate = DateTime.Now;
+        TransferExpiryDate = DateTime.Now + TimeSpan.FromDays(fsServer.config.DefaultTransferDaysValid);
     }
 
 
@@ -55,6 +75,7 @@ public partial class CreateTransferViewModel : ObservableObject
         TransferCancellationToken.Cancel();
     }
 
+    
     public void AddFile(CreateTransferFile file)
     {
         SelectedFiles.Add(file);
@@ -81,6 +102,11 @@ public partial class CreateTransferViewModel : ObservableObject
     {
         IsValidTransferState = SelectedFiles.Count > 0 && ValidateRecipientFiled();
         return;
+    }
+
+    [RelayCommand]
+    public void ValidatePassword()
+    {
     }
 
     private EmailAddressAttribute emailTool =  new EmailAddressAttribute();

--- a/FS/Views/CreateTransferView.xaml
+++ b/FS/Views/CreateTransferView.xaml
@@ -3,6 +3,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:utl="clr-namespace:FS.Utilities"
              x:Class="FS.Views.CreateTransferView">
     <ContentPage.Resources>
         <Style x:Key="InvalidEntryStyle" TargetType="Entry">
@@ -13,6 +14,7 @@
         </Style>
         <ResourceDictionary>
             <toolkit:InvertedBoolConverter x:Key="InvertedBoolConverter" />
+            <utl:BoolToFloatConverter x:Key="BoolToFloatConverter" />
         </ResourceDictionary>
     </ContentPage.Resources>
     <ContentPage.Content>
@@ -34,7 +36,14 @@
                    Source="astroman.png"
                    HeightRequest="185"
                    Aspect="AspectFit"
-                   SemanticProperties.Description="AstroMan" /> 
+                   SemanticProperties.Description="AstroMan" >
+                <Image.Shadow>
+                    <Shadow Brush="Black"
+                            Offset="20,20"
+                            Radius="20"
+                            Opacity="0.8" />
+                </Image.Shadow>
+            </Image> 
             <Grid Padding="{OnIdiom  '20,0,20,100', Phone='10,0,10,50'}" RowSpacing="10" Grid.Row="1" Grid.Column="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="45" />
@@ -47,7 +56,22 @@
                        Keyboard="Email"
                        Placeholder="Recipients Email/s ie: User1@example.com User2@example.com"
                        TextChanged="ValidateTranfer">
+                    <Entry.Style>
+                        <Style TargetType="Entry">
+                            <Setter Property="BackgroundColor" 
+                                    Value="{AppThemeBinding Light=WhiteSmoke, Dark=#1F1F1F}"></Setter>
+                            <Setter Property="TextColor" 
+                                    Value="{AppThemeBinding Light=Black, Dark=White}"></Setter>
+                        </Style>
+                    </Entry.Style>
+                    <Entry.Shadow>
+                        <Shadow Brush="Red"
+                                Offset="0,0"
+                                Opacity="{Binding IsInvalidEmails, Converter={StaticResource BoolToFloatConverter}}"
+                        ></Shadow>
+                    </Entry.Shadow>
                 </Entry>
+                
                 <Entry Grid.Row="1"
                        Text="{Binding Subject}"
                        Placeholder="Optional: Transfer subject"
@@ -79,12 +103,29 @@
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
                 <Entry Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Text="{Binding Password}"
+                       x:Name="PasswordEntry"
                        HorizontalOptions="Fill"
                        Placeholder="Optional: Password"
                        TextChanged="ValidateTranfer"
                        IsSpellCheckEnabled="False"
                        IsReadOnly="{Binding EncryptionEnabled}"
-                       ></Entry>
+                       IsVisible="{Binding EncryptionEnabled
+                            ,Converter={StaticResource InvertedBoolConverter}}">
+                    <Entry.Style>
+                        <Style TargetType="Entry">
+                            <Setter Property="BackgroundColor" 
+                                    Value="{AppThemeBinding Light=WhiteSmoke, Dark=#1F1F1F}"></Setter>
+                            <Setter Property="TextColor" 
+                                    Value="{AppThemeBinding Light=Black, Dark=White}"></Setter>
+                        </Style>
+                    </Entry.Style>
+                    <Entry.Shadow>
+                        <Shadow Brush="Red"
+                                Offset="0,0"
+                                Opacity="{Binding IsInvalidPassword, Converter={StaticResource BoolToFloatConverter}}"
+                                ></Shadow>
+                    </Entry.Shadow>
+                </Entry>
                     <Label Grid.Column="0" Grid.Row="1" Text="Expiry Date"></Label>
                     <DatePicker Grid.Column="1" Grid.Row="1" MinimumDate="{Binding TransferMinExpiryDate}"
                                 MaximumDate="{Binding TransferMaxExpiryDate}"

--- a/FS/Views/CreateTransferView.xaml
+++ b/FS/Views/CreateTransferView.xaml
@@ -22,7 +22,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="185" /> 
                 <RowDefinition Height="*" />
-               
+                <RowDefinition Height="*" /> 
                 <RowDefinition Height="30" />
                 <RowDefinition Height="50" />
                 <RowDefinition Height="50" />
@@ -49,7 +49,6 @@
                     <RowDefinition Height="45" />
                     <RowDefinition Height="45" />
                     <RowDefinition Height="100" />
-                    <RowDefinition Height="*" /><!-- ** file container --> 
                 </Grid.RowDefinitions>
                 <Entry Grid.Row="0" Text="{Binding Recipient}"
                        HorizontalOptions="Fill"
@@ -85,10 +84,7 @@
                         Placeholder="Optional: Transfer Description"
                 />
             
-                <ScrollView Grid.Row="3" Grid.Column="0">
-                    <VerticalStackLayout  x:Name="FileContainer">
-                    </VerticalStackLayout>
-                </ScrollView> 
+                
             </Grid>
             
             <Grid Padding="{OnIdiom  '20,0,20,100', Phone='10,0,10,50'}" RowSpacing="10" Grid.Row="1" Grid.Column="1">
@@ -133,23 +129,27 @@
                                 HorizontalOptions="End"/>
             </Grid>
             
-
+            <ScrollView Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2">
+                <FlexLayout  x:Name="FileContainer"
+                             Wrap="Wrap">
+                </FlexLayout>
+            </ScrollView> 
             
-            <VerticalStackLayout Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2">
+            <VerticalStackLayout Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2">
                 <Label x:Name="CounterCount"></Label>
                 <ProgressBar Progress="0.0"
                              ProgressColor="Orange" 
                              x:Name="CounterProgress"/>
             </VerticalStackLayout>
-            <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
+            <Button Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                     x:Name="SelectFilesBtn"
                     Text="Add Files" 
                     SemanticProperties.Hint="Select Files to Include in Transfer"
                     Clicked="SelectFiles"
                     HorizontalOptions="Fill" />
-            <Label Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding TransferActive}"></Label>
+            <Label Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding TransferActive}"></Label>
 
-                <Button Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                <Button Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                         x:Name="SendFilesBtn"
                         Text="Send Transfer" 
                         SemanticProperties.Hint="Send the selected files"
@@ -159,7 +159,7 @@
                                     Converter={StaticResource InvertedBoolConverter}}"
                         IsEnabled="{Binding IsValidTransferState}"
                 />
-                <Button  Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Text="Cancel" 
+                <Button  Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Text="Cancel" 
                          Clicked="CancelTransfer"
                          IsVisible="{Binding TransferActive}"
                          BorderColor="Firebrick"

--- a/FS/Views/CreateTransferView.xaml
+++ b/FS/Views/CreateTransferView.xaml
@@ -81,7 +81,7 @@
                 <Entry Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Text="{Binding Password}"
                        HorizontalOptions="Fill"
                        Placeholder="Optional: Password"
-                       TextChanged="ValidatePassword"
+                       TextChanged="ValidateTranfer"
                        IsSpellCheckEnabled="False"
                        IsReadOnly="{Binding EncryptionEnabled}"
                        ></Entry>

--- a/FS/Views/CreateTransferView.xaml
+++ b/FS/Views/CreateTransferView.xaml
@@ -3,7 +3,6 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-
              x:Class="FS.Views.CreateTransferView">
     <ContentPage.Resources>
         <Style x:Key="InvalidEntryStyle" TargetType="Entry">
@@ -17,75 +16,99 @@
         </ResourceDictionary>
     </ContentPage.Resources>
     <ContentPage.Content>
-        <!-- margin l,t,r,b -->
         <Grid Padding="{OnIdiom  '20,0,20,100', Phone='10,0,10,50'}" RowSpacing="10">
             <Grid.RowDefinitions>
                 <RowDefinition Height="185" /> 
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="45" />
-                <RowDefinition Height="100" />
-                <RowDefinition Height="*" /><!-- ** file container -->
+                <RowDefinition Height="*" />
+               
                 <RowDefinition Height="30" />
                 <RowDefinition Height="50" />
                 <RowDefinition Height="50" />
 
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="{OnIdiom  220, Phone=130}" />
+                <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>     
             <Image Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
-                Source="astroman.png"
-                HeightRequest="185"
-                Aspect="AspectFit"
-                SemanticProperties.Description="AstroMan" />
-            <Label Grid.Row="1" Grid.Column="0" Text="Recipient Email/s:"
-                   Padding="10,0"
-                   Style="{StaticResource SubHeadline}"></Label>
-            <Entry Grid.Row="1" Grid.Column="1" Text="{Binding Recipient}"
-                   HorizontalOptions="Fill"
-                   Keyboard="Email"
-                   TextChanged="ValidateTranfer">
-            </Entry>
-            <Label Grid.Row="2" Grid.Column="0"  Text="Subject:"
-                   Padding="10,0"
-                   Style="{StaticResource SubHeadline}"
-            />
-            <Entry Grid.Row="2" Grid.Column="1"
-                   Text="{Binding Subject}"
-                   HorizontalOptions="Fill"
-            />
-
-            <Label Grid.Row="3" Grid.Column="0"  Text="Message:" 
-                   Padding="10,0"
-                   Style="{StaticResource SubHeadline}"> </Label>
-            <Editor Grid.Row="3" Grid.Column="1"
-                    HorizontalOptions="Fill"
-                    VerticalOptions="Fill"
-                    Text="{Binding Description}"
-                    />
+                   Source="astroman.png"
+                   HeightRequest="185"
+                   Aspect="AspectFit"
+                   SemanticProperties.Description="AstroMan" /> 
+            <Grid Padding="{OnIdiom  '20,0,20,100', Phone='10,0,10,50'}" RowSpacing="10" Grid.Row="1" Grid.Column="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="45" />
+                    <RowDefinition Height="45" />
+                    <RowDefinition Height="100" />
+                    <RowDefinition Height="*" /><!-- ** file container --> 
+                </Grid.RowDefinitions>
+                <Entry Grid.Row="0" Text="{Binding Recipient}"
+                       HorizontalOptions="Fill"
+                       Keyboard="Email"
+                       Placeholder="Recipients Email/s ie: User1@example.com User2@example.com"
+                       TextChanged="ValidateTranfer">
+                </Entry>
+                <Entry Grid.Row="1"
+                       Text="{Binding Subject}"
+                       Placeholder="Optional: Transfer subject"
+                       HorizontalOptions="Fill"
+                />
             
-            <ScrollView Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2">
-                <VerticalStackLayout  x:Name="FileContainer">
-                </VerticalStackLayout>
-            </ScrollView>
+                <Editor Grid.Row="2"
+                        HorizontalOptions="Fill"
+                        VerticalOptions="Fill"
+                        Text="{Binding Description}"
+                        Placeholder="Optional: Transfer Description"
+                />
+            
+                <ScrollView Grid.Row="3" Grid.Column="0">
+                    <VerticalStackLayout  x:Name="FileContainer">
+                    </VerticalStackLayout>
+                </ScrollView> 
+            </Grid>
+            
+            <Grid Padding="{OnIdiom  '20,0,20,100', Phone='10,0,10,50'}" RowSpacing="10" Grid.Row="1" Grid.Column="1">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="45" />
+                    <RowDefinition Height="45" />
+                    <RowDefinition Height="100" />
+                    <RowDefinition Height="*" /><!-- ** file container --> 
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Entry Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Text="{Binding Password}"
+                       HorizontalOptions="Fill"
+                       Placeholder="Optional: Password"
+                       TextChanged="ValidatePassword"
+                       IsSpellCheckEnabled="False"
+                       IsReadOnly="{Binding EncryptionEnabled}"
+                       ></Entry>
+                    <Label Grid.Column="0" Grid.Row="1" Text="Expiry Date"></Label>
+                    <DatePicker Grid.Column="1" Grid.Row="1" MinimumDate="{Binding TransferMinExpiryDate}"
+                                MaximumDate="{Binding TransferMaxExpiryDate}"
+                                Date="{Binding TransferExpiryDate}" 
+                                HorizontalOptions="End"/>
+            </Grid>
+            
 
             
-            <VerticalStackLayout Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2">
+            <VerticalStackLayout Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2">
                 <Label x:Name="CounterCount"></Label>
                 <ProgressBar Progress="0.0"
                              ProgressColor="Orange" 
                              x:Name="CounterProgress"/>
             </VerticalStackLayout>
-            <Button Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
+            <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                     x:Name="SelectFilesBtn"
                     Text="Add Files" 
                     SemanticProperties.Hint="Select Files to Include in Transfer"
                     Clicked="SelectFiles"
                     HorizontalOptions="Fill" />
-            <Label Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding TransferActive}"></Label>
+            <Label Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding TransferActive}"></Label>
 
-                <Button Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
+                <Button Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                         x:Name="SendFilesBtn"
                         Text="Send Transfer" 
                         SemanticProperties.Hint="Send the selected files"
@@ -95,12 +118,14 @@
                                     Converter={StaticResource InvertedBoolConverter}}"
                         IsEnabled="{Binding IsValidTransferState}"
                 />
-                <Button  Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Text="Cancel" 
+                <Button  Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Text="Cancel" 
                          Clicked="CancelTransfer"
                          IsVisible="{Binding TransferActive}"
                          BorderColor="Firebrick"
                          BorderWidth="5"
                 ></Button>
-        </Grid>
+        </Grid> 
+        <!-- margin l,t,r,b -->
+       
     </ContentPage.Content>
 </ContentPage>

--- a/FS/Views/CreateTransferView.xaml.cs
+++ b/FS/Views/CreateTransferView.xaml.cs
@@ -96,6 +96,8 @@ public partial class CreateTransferView : ContentPage
         foreach (var file in viewModel.SelectedFiles)
         {
             var container = new HorizontalStackLayout();
+            container.HeightRequest = 60;
+            container.Margin = new Thickness(5,0);
             viewModel.FileListIndex[file.FullPath] = container.Id;
             container.AutomationId = container.Id.ToString();
             var name = new Label();

--- a/FS/Views/CreateTransferView.xaml.cs
+++ b/FS/Views/CreateTransferView.xaml.cs
@@ -197,4 +197,9 @@ public partial class CreateTransferView : ContentPage
     {
         viewModel.ValidateTransfer();
     }
+    
+    private void ValidatePassword(object? sender, TextChangedEventArgs e)
+    {
+        viewModel.ValidatePassword();
+    }
 }

--- a/FS/Views/TransferDetailView.xaml.cs
+++ b/FS/Views/TransferDetailView.xaml.cs
@@ -48,18 +48,18 @@ public partial class TransferDetailView : ContentPage
     {
         try
         {
-        var request = await viewModel.FsServer.GetDownloadStream(files.Select(x => x.Id.ToString()).ToArray());
-        var tmpFileName = files.Length == 1 ? files[0].Name : $"{viewModel.Transfer.Subject ?? "Transfer"}.zip";
-        var fileSaverResult = await fileSaver.SaveAsync(tmpFileName, request);
-        fileSaverResult.EnsureSuccess();
-        await Toast.Make($"File is saved: {fileSaverResult.FilePath}").Show();
-    }
-    catch (Exception e)
-    {
-        await Toast.Make($"File failed to download").Show();
-        Debug.WriteLine("Failed to save file.");
-        Debug.WriteLine(e);
-    }
+            var request = await viewModel.FsServer.GetDownloadStream(files.Select(x => x.Id.ToString()).ToArray());
+            var tmpFileName = files.Length == 1 ? files[0].Name : $"{viewModel.Transfer.Subject ?? "Transfer"}.zip";
+            var fileSaverResult = await fileSaver.SaveAsync(tmpFileName, request);
+            fileSaverResult.EnsureSuccess();
+            await Toast.Make($"File is saved: {fileSaverResult.FilePath}").Show();
+        }
+        catch (Exception e)
+        {
+            await Toast.Make($"File failed to download").Show();
+            Debug.WriteLine("Failed to save file.");
+            Debug.WriteLine(e);
+        }
     }
     
     public async void ShowAuditLog(object sender, EventArgs args)

--- a/FS/Views/TransferDetailView.xaml.cs
+++ b/FS/Views/TransferDetailView.xaml.cs
@@ -25,12 +25,22 @@ public partial class TransferDetailView : ContentPage
 
     public async void SaveFile(object sender, EventArgs args)
     {
-            //todo: this is logged as the recipient, work out a way to use download.php with our auth token.
-            var file = (TransferFile)((ItemTappedEventArgs)args).Item;
-            Download(new []{file});
+        if (viewModel.Transfer.Options is not null && viewModel.Transfer.Options.ContainsKey("encryption") && viewModel.Transfer.Options["encryption"])
+        {   //todo: add download for encrypted files.
+            await Toast.Make($"Cannot download encrypted file").Show();
+            return;
+        }
+        //todo: this is logged as the recipient, work out a way to use download.php with our auth token.
+        var file = (TransferFile)((ItemTappedEventArgs)args).Item;
+        Download(new []{file});
     }
     public async void SaveTransfer(object sender, EventArgs args)
     {
+        if (viewModel.Transfer.Options is not null && viewModel.Transfer.Options.ContainsKey("encryption") && viewModel.Transfer.Options["encryption"])
+        {
+            await Toast.Make($"Cannot download encrypted transfer").Show();
+            return;
+        }
         Download(viewModel.Transfer.Files);
     }
 


### PR DESCRIPTION
AES-GCM end to end encryption now supported for transfers.

- Stops users downloading encrypted files as we cannot decrypt them.
- Collects encryption information from server and hides ui elements if I don't support that mode.
- Auto encrypts transfer by entering a password.
- Validates fields to servers standards and provides user feedback.
- Encrypts the chunks using the same method as was done in filesender.py earlier this year.